### PR TITLE
Change some gdb stub log::info to log::debug

### DIFF
--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -716,7 +716,7 @@ impl SwBreakpoint for MachineTarget {
         addr: <Self::Arch as Arch>::Usize,
         kind: <Self::Arch as Arch>::BreakpointKind,
     ) -> TargetResult<bool, Self> {
-        log::info!("add_sw_breakpoint: {:#x} {}", addr, kind);
+        log::debug!("add_sw_breakpoint: {:#x} {}", addr, kind);
         Ok(self.machine.add_breakpoint(addr))
     }
 
@@ -725,7 +725,7 @@ impl SwBreakpoint for MachineTarget {
         addr: <Self::Arch as Arch>::Usize,
         kind: <Self::Arch as Arch>::BreakpointKind,
     ) -> TargetResult<bool, Self> {
-        log::info!("remove_sw_breakpoint: {:#x} {}", addr, kind);
+        log::debug!("remove_sw_breakpoint: {:#x} {}", addr, kind);
         Ok(self.machine.clear_breakpoint(addr))
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -258,7 +258,7 @@ fn main() -> anyhow::Result<ExitCode> {
                                     break ExitCode::SUCCESS;
                                 }
                             } else {
-                                log::info!("Breakpoint hit @ {eip:x}");
+                                log::debug!("Breakpoint hit @ {eip:x}");
                                 debugger.breakpoint(&mut target)?;
                                 MachineState::Stopped
                             }


### PR DESCRIPTION
This is pretty noisy and I ended up hiding the retrowin32 output in the mwcc-debugger script, but this turned out to be a terrible decision because it hides compiler errors as well